### PR TITLE
Feat: 맵 리스트 & 상세 페이지 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,19 +3,25 @@ import { Routes, Route, Link } from "react-router-dom";
 import Lobby from "./Lobby.jsx";
 import ChatRoom from "./ChatRoom.jsx";
 import CreateMap from "./CreateMap.jsx";
+import MapList from "./MapList.jsx";
+import MapDetail from "./MapDetail";
+
 
 function App() {
     return (
         <div>
             <nav>
                 <Link to="/">홈</Link> |
-                <Link to="/create-map">맵 만들기</Link>
+                <Link to="/create-map">맵 만들기</Link> |
+                <Link to="/map-list">맵 리스트</Link>
             </nav>
 
             <Routes>
                 <Route path="/" element={<Lobby />} />
                 <Route path="/room/:roomName" element={<ChatRoom />} />
                 <Route path="/create-map" element={<CreateMap />} />
+                <Route path="/map-list" element={<MapList />} />
+                <Route path="/maps/:id" element={<MapDetail />} />
             </Routes>
         </div>
     );

--- a/src/MapDetail.jsx
+++ b/src/MapDetail.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+const API_BASE_URL = "http://localhost:8080/api";
+
+const MapDetail = () => {
+    const { id } = useParams();
+    const [map, setMap] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchMapDetail = async () => {
+            try {
+                const response = await fetch(`${API_BASE_URL}/maps/${id}`);
+                if (!response.ok) {
+                    throw new Error("맵 데이터를 불러오는 데 실패했습니다.");
+                }
+                const data = await response.json();
+                setMap(data);
+            } catch (err) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchMapDetail();
+    }, [id]);
+
+    if (loading) return <p>로딩 중...</p>;
+    if (error) return <p>오류 발생: {error}</p>;
+    if (!map) return <p>맵 정보를 찾을 수 없습니다.</p>;
+
+    return (
+        <div>
+            <h2>{map.name}</h2>
+            <p>{map.description}</p>
+        </div>
+    );
+};
+
+export default MapDetail;

--- a/src/MapList.jsx
+++ b/src/MapList.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+const API_BASE_URL = "http://localhost:8080/api";
+
+const MapList = () => {
+    const [maps, setMaps] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchPublicMaps = async () => {
+            try {
+                const response = await fetch(`${API_BASE_URL}/maps/public`);
+                if (!response.ok) {
+                    throw new Error("공개된 맵 데이터를 불러오는 데 실패했습니다.");
+                }
+                const data = await response.json();
+                setMaps(data);
+            } catch (err) {
+                setError(err.message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchPublicMaps();
+    }, []);
+
+    if (loading) return <p>로딩 중...</p>;
+    if (error) return <p>오류 발생: {error}</p>;
+
+    return (
+        <div>
+            <h2>공개된 맵 목록</h2>
+            {maps.length === 0 ? (
+                <p>등록된 공개 맵이 없습니다.</p>
+            ) : (
+                <ul>
+                    {maps.map((map) => (
+                        <li key={map.id}>
+                            <Link to={`/maps/${map.id}`}>
+                                <strong>{map.name}</strong> - {map.description}
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+export default MapList;


### PR DESCRIPTION
Closed #5 

- /api/maps/public API 호출하여 공개 맵 리스트 조회 (`MapList.jsx` 수정)
- /api/maps/{id} API 호출하여 특정 맵의 상세 정보 조회 (`MapDetail.jsx` 생성)
- useEffect를 사용한 데이터 fetch 및 상태 관리
- App.jsx에서 `/maps/:id` 경로를 추가하여 상세 페이지 연결
- 맵 설명(description)도 화면에 표시