### PR TITLE
Refactor: CreateMap' 컴포넌트에서 'Step1'과 'Step2' 컴포넌트의 이름 변경

### DIFF
--- a/src/createMap/CreateMap.jsx
+++ b/src/createMap/CreateMap.jsx
@@ -1,13 +1,14 @@
 import { Routes, Route } from "react-router-dom";
-import Step2 from "./CreateMapStep2.js";
+import CreateMapStep1 from "./CreateMapStep1.js";
+import CreateMapStep2 from "./CreateMapStep2.js";
 
 const CreateMap = () => {
     return (
         <div>
             <h2>맵 만들기</h2>
             <Routes>
-                <Route path="/" element={<Step1 />} />
-                <Route path="step2" element={<Step2 />} />
+                <Route path="/" element={<CreateMapStep1 />} />
+                <Route path="step2" element={<CreateMapStep2 />} />
             </Routes>
         </div>
     );


### PR DESCRIPTION

### 변경 사항:
- `CreateMap` 컴포넌트에서 `Step1` 컴포넌트의 이름을 `CreateMapStep1`으로 변경하고, `Step2` 컴포넌트도 `CreateMapStep2`로 이름을 변경.
- `Routes`에서 `Step1`과 `Step2`를 각각 `CreateMapStep1`과 `CreateMapStep2`로 바꿔서 코드의 명확성과 일관성을 높였습니다.

### 이유:
- 이름 변경을 통해 파일명과 컴포넌트명이 일치하도록 개선하여 코드의 가독성을 높였습니다.
- 기존 코드에서 사용된 `Step1`, `Step2`의 명확한 컴포넌트 이름을 통해 역할을 쉽게 알 수 있도록 변경했습니다.
